### PR TITLE
fix!: for pairwise alignment, only apply gap_extend penalty for each extension of a gap beyond length 1, not upon gap opening

### DIFF
--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -1994,7 +1994,7 @@ mod banded {
         println!("\naln:\n{}", alignment.pretty(x, y, 80));
 
         println!("score:{}", alignment.score);
-        assert_eq!(alignment.score, -9);
+        assert_eq!(alignment.score, -7);
         assert_eq!(alignment.ystart, 0);
         assert_eq!(alignment.xstart, 0);
         assert_eq!(
@@ -2168,7 +2168,7 @@ mod banded {
         let alignment = aligner.custom(x, y);
 
         println!("{}", alignment.pretty(x, y, 80));
-        assert_eq!(alignment.score, 7);
+        assert_eq!(alignment.score, 8);
     }
 
     #[test]

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -51,7 +51,7 @@
 //! // explanation
 //!
 //! // The following example considers a modification of the semiglobal mode where you are allowed
-//! // to skip a prefix of the target sequence x, for a penalty of -10, but you have to consume
+//! // to skip a prefix of the target sequence x, for a penalty of -5, but you have to consume
 //! // the rest of the string in the alignment
 //!
 //! let scoring = Scoring {
@@ -59,7 +59,7 @@
 //!     gap_extend: -1,
 //!     match_fn: |a: u8, b: u8| if a == b { 1i32 } else { -3i32 },
 //!     match_scores: Some((1, -3)),
-//!     xclip_prefix: -10,
+//!     xclip_prefix: -5,
 //!     xclip_suffix: MIN_SCORE,
 //!     yclip_prefix: 0,
 //!     yclip_suffix: 0,

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -69,7 +69,7 @@
 //! let mut aligner = Aligner::with_capacity_and_scoring(x.len(), y.len(), scoring, k, w);
 //! let alignment = aligner.custom(x, y);
 //! println!("{}", alignment.pretty(x, y, 80));
-//! assert_eq!(alignment.score, 49);
+//! assert_eq!(alignment.score, 54);
 //! let mut correct_ops = Vec::new();
 //! correct_ops.push(Yclip(4));
 //! correct_ops.push(Xclip(6));

--- a/src/alignment/pairwise/banded.rs
+++ b/src/alignment/pairwise/banded.rs
@@ -441,13 +441,12 @@ impl<F: MatchFunc> Aligner<F> {
                 let mut tb = TracebackCell::new();
                 tb.set_all(TB_START);
                 if i == 1 {
-                    self.I[curr][i] = self.scoring.gap_open + self.scoring.gap_extend;
+                    self.I[curr][i] = self.scoring.gap_open;
                     tb.set_i_bits(TB_START);
                 } else {
                     // Insert all i characters
-                    let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32);
-                    let c_score =
-                        self.scoring.xclip_prefix + self.scoring.gap_open + self.scoring.gap_extend; // Clip then insert
+                    let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32 - 1);
+                    let c_score = self.scoring.xclip_prefix + self.scoring.gap_open; // Clip then insert
                     if i_score > c_score {
                         self.I[curr][i] = i_score;
                         tb.set_i_bits(TB_INS);
@@ -513,13 +512,12 @@ impl<F: MatchFunc> Aligner<F> {
                 self.I[curr][0] = MIN_SCORE;
 
                 if j == 1 {
-                    self.D[curr][0] = self.scoring.gap_open + self.scoring.gap_extend;
+                    self.D[curr][0] = self.scoring.gap_open;
                     tb.set_d_bits(TB_START);
                 } else {
                     // Delete all j characters
-                    let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32);
-                    let c_score =
-                        self.scoring.yclip_prefix + self.scoring.gap_open + self.scoring.gap_extend;
+                    let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1);
+                    let c_score = self.scoring.yclip_prefix + self.scoring.gap_open;
                     if d_score > c_score {
                         self.D[curr][0] = d_score;
                         tb.set_d_bits(TB_DEL);
@@ -561,7 +559,7 @@ impl<F: MatchFunc> Aligner<F> {
                     } else {
                         self.scoring.yclip_prefix
                     },
-                    self.scoring.gap_open + self.scoring.gap_extend * (j as i32),
+                    self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1),
                 );
 
             for i in max(1, i_start)..i_end {
@@ -571,7 +569,7 @@ impl<F: MatchFunc> Aligner<F> {
                 let m_score = self.S[prev][i - 1] + self.scoring.match_fn.score(p, q);
 
                 let i_score = self.I[curr][i - 1] + self.scoring.gap_extend;
-                let s_score = self.S[curr][i - 1] + self.scoring.gap_open + self.scoring.gap_extend;
+                let s_score = self.S[curr][i - 1] + self.scoring.gap_open;
                 let mut best_i_score;
                 if i_score > s_score {
                     best_i_score = i_score;
@@ -581,8 +579,7 @@ impl<F: MatchFunc> Aligner<F> {
                     tb.set_i_bits(self.traceback.get(i - 1, j).get_s_bits());
                 }
                 if j == n {
-                    let clip_score =
-                        self.Sn[i - 1] + self.scoring.gap_open + self.scoring.gap_extend;
+                    let clip_score = self.Sn[i - 1] + self.scoring.gap_open;
                     if clip_score > best_i_score {
                         best_i_score = clip_score;
                         tb.set_i_bits(TB_YCLIP_SUFFIX);
@@ -590,7 +587,7 @@ impl<F: MatchFunc> Aligner<F> {
                 }
 
                 let d_score = self.D[prev][i] + self.scoring.gap_extend;
-                let s_score = self.S[prev][i] + self.scoring.gap_open + self.scoring.gap_extend;
+                let s_score = self.S[prev][i] + self.scoring.gap_open;
                 let best_d_score;
                 if d_score > s_score {
                     best_d_score = d_score;
@@ -629,7 +626,7 @@ impl<F: MatchFunc> Aligner<F> {
 
                 let yclip_score = self.scoring.yclip_prefix
                     + self.scoring.gap_open
-                    + self.scoring.gap_extend * (i as i32);
+                    + self.scoring.gap_extend * (i as i32 - 1);
                 if yclip_score > best_s_score {
                     best_s_score = yclip_score;
                     tb.set_s_bits(TB_YCLIP_PREFIX);
@@ -699,7 +696,7 @@ impl<F: MatchFunc> Aligner<F> {
         for i in max(1, self.band.ranges[n].start)..self.band.ranges[n].end {
             let j = n;
             let curr = j % 2;
-            let s_score = self.S[curr][i - 1] + self.scoring.gap_open + self.scoring.gap_extend;
+            let s_score = self.S[curr][i - 1] + self.scoring.gap_open;
             if s_score > self.I[curr][i] {
                 self.I[curr][i] = s_score;
                 let s_bit = self.traceback.get(i - 1, j).get_s_bits();
@@ -717,7 +714,7 @@ impl<F: MatchFunc> Aligner<F> {
         }
 
         for j in 1..=n {
-            let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32);
+            let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1);
             if d_score > self.scoring.yclip_prefix {
                 self.traceback.get_mut(0, j).set_s_bits(TB_DEL);
             } else {
@@ -738,7 +735,7 @@ impl<F: MatchFunc> Aligner<F> {
         }
 
         for i in 1..=m {
-            let c_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32);
+            let c_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32 - 1);
             if c_score > self.scoring.xclip_prefix {
                 self.traceback.get_mut(i, 0).set_s_bits(TB_INS);
             } else {
@@ -827,7 +824,7 @@ impl<F: MatchFunc> Aligner<F> {
         // Handle the case when the traceback ends outside the band other than at (0, 0)
         if i != 0 {
             // Insert all i characters
-            let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32);
+            let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32 - 1);
             if i_score > self.scoring.xclip_prefix {
                 operations.resize(operations.len() + i, AlignmentOperation::Ins);
                 xstart = 0;
@@ -838,7 +835,7 @@ impl<F: MatchFunc> Aligner<F> {
         }
         if j != 0 {
             // Delete all j characters
-            let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32);
+            let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1);
             if d_score > self.scoring.yclip_prefix {
                 operations.resize(operations.len() + j, AlignmentOperation::Del);
                 ystart = 0;

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -619,8 +619,7 @@ impl<F: MatchFunc> Aligner<F> {
                 } else {
                     // Insert all i characters
                     let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32 - 1);
-                    let c_score =
-                        self.scoring.xclip_prefix + self.scoring.gap_open; // Clip then insert
+                    let c_score = self.scoring.xclip_prefix + self.scoring.gap_open; // Clip then insert
                     if i_score > c_score {
                         self.I[k][i] = i_score;
                         tb.set_i_bits(TB_INS);
@@ -678,8 +677,7 @@ impl<F: MatchFunc> Aligner<F> {
                 } else {
                     // Delete all j characters
                     let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1);
-                    let c_score =
-                        self.scoring.yclip_prefix + self.scoring.gap_open;
+                    let c_score = self.scoring.yclip_prefix + self.scoring.gap_open;
                     if d_score > c_score {
                         self.D[curr][0] = d_score;
                         tb.set_d_bits(TB_DEL);

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -1480,7 +1480,7 @@ mod tests {
         println!("\naln:\n{}", alignment.pretty(x, y, 80));
 
         println!("score:{}", alignment.score);
-        assert_eq!(alignment.score, -9);
+        assert_eq!(alignment.score, -7);
         assert_eq!(alignment.ystart, 0);
         assert_eq!(alignment.xstart, 0);
         assert_eq!(
@@ -1678,7 +1678,7 @@ mod tests {
         let alignment = aligner.custom(x, y);
 
         println!("{}", alignment.pretty(x, y, 80));
-        assert_eq!(alignment.score, 7);
+        assert_eq!(alignment.score, 8);
     }
 
     #[test]

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -122,17 +122,18 @@
 //!     yclip_prefix: 0,
 //!     yclip_suffix: 0,
 //! };
-//! let x = b"GGGGGGACGTACGTACGT";
+//! let x = b"GGGGGGGGGACGTACGTACGT";
 //! let y = b"AAAAACGTACGTACGTAAAA";
 //! let mut aligner = Aligner::with_capacity_and_scoring(x.len(), y.len(), scoring);
 //! let alignment = aligner.custom(x, y);
 //! println!("{}", alignment.pretty(x, y, 80));
+//! println!("{}", alignment.score);
 //! assert_eq!(alignment.score, 2);
 //! assert_eq!(
 //!     alignment.operations,
 //!     [
 //!         Yclip(4),
-//!         Xclip(6),
+//!         Xclip(9),
 //!         Match,
 //!         Match,
 //!         Match,

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -1400,7 +1400,21 @@ mod tests {
 
         assert_eq!(
             alignment.operations,
-            [Match, Match, Match, Match, Ins, Match, Match, Match, Match, Match, Match]
+            [
+                Xclip(4),
+                Match,
+                Match,
+                Match,
+                Match,
+                Del,
+                Match,
+                Match,
+                Match,
+                Match,
+                Match,
+                Match,
+                Yclip(3)
+            ]
         );
     }
 

--- a/src/alignment/pairwise/mod.rs
+++ b/src/alignment/pairwise/mod.rs
@@ -222,7 +222,7 @@ where
 ///
 /// An [affine gap score model](https://en.wikipedia.org/wiki/Gap_penalty#Affine)
 /// is used so that the gap score for a length `k` is:
-/// `GapScore(k) = gap_open + gap_extend * k`
+/// `GapScore(k) = gap_open + gap_extend * (k - 1)`
 #[derive(
     Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize,
 )]
@@ -614,13 +614,13 @@ impl<F: MatchFunc> Aligner<F> {
                 let mut tb = TracebackCell::new();
                 tb.set_all(TB_START);
                 if i == 1 {
-                    self.I[k][i] = self.scoring.gap_open + self.scoring.gap_extend;
+                    self.I[k][i] = self.scoring.gap_open;
                     tb.set_i_bits(TB_START);
                 } else {
                     // Insert all i characters
-                    let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32);
+                    let i_score = self.scoring.gap_open + self.scoring.gap_extend * (i as i32 - 1);
                     let c_score =
-                        self.scoring.xclip_prefix + self.scoring.gap_open + self.scoring.gap_extend; // Clip then insert
+                        self.scoring.xclip_prefix + self.scoring.gap_open; // Clip then insert
                     if i_score > c_score {
                         self.I[k][i] = i_score;
                         tb.set_i_bits(TB_INS);
@@ -673,13 +673,13 @@ impl<F: MatchFunc> Aligner<F> {
                 self.I[curr][0] = MIN_SCORE;
 
                 if j == 1 {
-                    self.D[curr][0] = self.scoring.gap_open + self.scoring.gap_extend;
+                    self.D[curr][0] = self.scoring.gap_open;
                     tb.set_d_bits(TB_START);
                 } else {
                     // Delete all j characters
-                    let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32);
+                    let d_score = self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1);
                     let c_score =
-                        self.scoring.yclip_prefix + self.scoring.gap_open + self.scoring.gap_extend;
+                        self.scoring.yclip_prefix + self.scoring.gap_open;
                     if d_score > c_score {
                         self.D[curr][0] = d_score;
                         tb.set_d_bits(TB_DEL);
@@ -717,7 +717,7 @@ impl<F: MatchFunc> Aligner<F> {
             let xclip_score = self.scoring.xclip_prefix
                 + max(
                     self.scoring.yclip_prefix,
-                    self.scoring.gap_open + self.scoring.gap_extend * (j as i32),
+                    self.scoring.gap_open + self.scoring.gap_extend * (j as i32 - 1),
                 );
             for i in 1..m + 1 {
                 let p = x[i - 1];
@@ -726,7 +726,7 @@ impl<F: MatchFunc> Aligner<F> {
                 let m_score = self.S[prev][i - 1] + self.scoring.match_fn.score(p, q);
 
                 let i_score = self.I[curr][i - 1] + self.scoring.gap_extend;
-                let s_score = self.S[curr][i - 1] + self.scoring.gap_open + self.scoring.gap_extend;
+                let s_score = self.S[curr][i - 1] + self.scoring.gap_open;
                 let best_i_score;
                 if i_score > s_score {
                     best_i_score = i_score;
@@ -737,7 +737,7 @@ impl<F: MatchFunc> Aligner<F> {
                 }
 
                 let d_score = self.D[prev][i] + self.scoring.gap_extend;
-                let s_score = self.S[prev][i] + self.scoring.gap_open + self.scoring.gap_extend;
+                let s_score = self.S[prev][i] + self.scoring.gap_open;
                 let best_d_score;
                 if d_score > s_score {
                     best_d_score = d_score;
@@ -772,7 +772,7 @@ impl<F: MatchFunc> Aligner<F> {
 
                 let yclip_score = self.scoring.yclip_prefix
                     + self.scoring.gap_open
-                    + self.scoring.gap_extend * (i as i32);
+                    + self.scoring.gap_extend * (i as i32 - 1);
                 if yclip_score > best_s_score {
                     best_s_score = yclip_score;
                     tb.set_s_bits(TB_YCLIP_PREFIX);
@@ -818,7 +818,7 @@ impl<F: MatchFunc> Aligner<F> {
         for i in 1..=m {
             let j = n;
             let curr = j % 2;
-            let s_score = self.S[curr][i - 1] + self.scoring.gap_open + self.scoring.gap_extend;
+            let s_score = self.S[curr][i - 1] + self.scoring.gap_open;
             if s_score > self.I[curr][i] {
                 self.I[curr][i] = s_score;
                 let s_bit = self.traceback.get(i - 1, j).get_s_bits();
@@ -1372,6 +1372,37 @@ mod tests {
         assert_eq!(
             alignment.operations,
             [Subst, Match, Ins, Ins, Ins, Ins, Ins, Ins, Subst, Match, Match,]
+        );
+    }
+
+    #[test]
+    fn test_issue656() {
+        let x = b"CTCCCTGTTCTTAT";
+        let y = b"CTGTCTCTTATACA";
+        let scoring = Scoring {
+            gap_open: -6,
+            gap_extend: -1,
+            match_fn: |a: u8, b: u8| if a == b { 1 } else { -1 },
+            match_scores: None,
+            xclip_prefix: 0,
+            xclip_suffix: MIN_SCORE,
+            yclip_prefix: MIN_SCORE,
+            yclip_suffix: 0,
+        };
+
+        let mut aligner = Aligner::with_scoring(scoring);
+        let alignment = aligner.custom(x, y);
+        println!("Alignment between x and y:");
+        println!("x: {}", std::str::from_utf8(x).unwrap());
+        println!("y: {}", std::str::from_utf8(y).unwrap());
+        println!("\nResult:");
+        println!("{}", alignment.pretty(x, y, 80));
+        println!("\nAlignment details:");
+        println!("{:?}", alignment);
+
+        assert_eq!(
+            alignment.operations,
+            [Match, Match, Match, Match, Ins, Match, Match, Match, Match, Match, Match]
         );
     }
 


### PR DESCRIPTION
fixes #656 