### PR TITLE
fix(io): reject non-IUPAC characters in FASTA/FASTQ Record::check

### DIFF
--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -962,12 +962,25 @@ impl Record {
     }
 
     /// Check validity of Fasta record.
+    ///
+    /// Verifies that the record has a non-empty id, that the sequence is
+    /// ASCII, and that every sequence character is a valid IUPAC nucleotide
+    /// or amino acid code (any ASCII letter), a gap (`-`, `.`), or a stop
+    /// (`*`). Characters such as digits, whitespace, or symbols like `@`
+    /// are rejected.
     pub fn check(&self) -> Result<(), &str> {
         if self.id().is_empty() {
             return Err("Expecting id for Fasta record.");
         }
         if !self.seq.is_ascii() {
             return Err("Non-ascii character found in sequence.");
+        }
+        if !self
+            .seq
+            .bytes()
+            .all(|b| b.is_ascii_alphabetic() || matches!(b, b'-' | b'.' | b'*'))
+        {
+            return Err("Non-IUPAC character found in sequence.");
         }
 
         Ok(())
@@ -1254,6 +1267,19 @@ TTTA
             record.check().is_err(),
             "check() should return Err if FASTA sequence is not ASCII"
         );
+    }
+
+    // Regression test for https://github.com/rust-bio/rust-bio/issues/472:
+    // sequence characters that are ASCII but not valid IUPAC residues (e.g.
+    // `@`, `#`, digits, whitespace) used to slip past `check()`.
+    #[test]
+    fn test_check_record_seq_has_non_iupac_raises_err() {
+        let record = Record::with_attrs("id", None, b"ACGT@A");
+
+        let actual = record.check().unwrap_err();
+        let expected = "Non-IUPAC character found in sequence.";
+
+        assert_eq!(actual, expected)
     }
 
     #[test]

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -964,10 +964,10 @@ impl Record {
     /// Check validity of Fasta record.
     ///
     /// Verifies that the record has a non-empty id, that the sequence is
-    /// ASCII, and that every sequence character is a valid IUPAC nucleotide
-    /// or amino acid code (any ASCII letter), a gap (`-`, `.`), or a stop
-    /// (`*`). Characters such as digits, whitespace, or symbols like `@`
-    /// are rejected.
+    /// ASCII, and that every sequence character is an ASCII letter (covering
+    /// e.g. IUPAC nucleotide and amino acid codes), a gap (`-`, `.`), or a
+    /// stop (`*`). Characters such as digits, whitespace, or symbols like
+    /// `@` are rejected.
     pub fn check(&self) -> Result<(), &str> {
         if self.id().is_empty() {
             return Err("Expecting id for Fasta record.");
@@ -980,7 +980,7 @@ impl Record {
             .bytes()
             .all(|b| b.is_ascii_alphabetic() || matches!(b, b'-' | b'.' | b'*'))
         {
-            return Err("Non-IUPAC character found in sequence.");
+            return Err("Invalid character found in sequence.");
         }
 
         Ok(())
@@ -1277,7 +1277,7 @@ TTTA
         let record = Record::with_attrs("id", None, b"ACGT@A");
 
         let actual = record.check().unwrap_err();
-        let expected = "Non-IUPAC character found in sequence.";
+        let expected = "Invalid character found in sequence.";
 
         assert_eq!(actual, expected)
     }

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -382,6 +382,13 @@ impl Record {
         if !self.seq.is_ascii() {
             return Err("Non-ascii character found in sequence.");
         }
+        if !self
+            .seq
+            .bytes()
+            .all(|b| b.is_ascii_alphabetic() || matches!(b, b'-' | b'.' | b'*'))
+        {
+            return Err("Non-IUPAC character found in sequence.");
+        }
         if !self.qual.is_ascii() {
             return Err("Non-ascii character found in qualities.");
         }
@@ -726,6 +733,19 @@ IIIIIIJJJJJJ
 
         let actual = record.check().unwrap_err();
         let expected = "Non-ascii character found in sequence.";
+
+        assert_eq!(actual, expected)
+    }
+
+    // Regression test for https://github.com/rust-bio/rust-bio/issues/472:
+    // sequence characters that are ASCII but not valid IUPAC residues (e.g.
+    // `@`, `#`, digits, whitespace) used to slip past `check()`.
+    #[test]
+    fn test_check_record_seq_has_non_iupac_raises_err() {
+        let record = Record::with_attrs("id", None, b"ACGT@A", b"!!!!!!");
+
+        let actual = record.check().unwrap_err();
+        let expected = "Non-IUPAC character found in sequence.";
 
         assert_eq!(actual, expected)
     }

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -387,7 +387,7 @@ impl Record {
             .bytes()
             .all(|b| b.is_ascii_alphabetic() || matches!(b, b'-' | b'.' | b'*'))
         {
-            return Err("Non-IUPAC character found in sequence.");
+            return Err("Invalid character found in sequence.");
         }
         if !self.qual.is_ascii() {
             return Err("Non-ascii character found in qualities.");
@@ -745,7 +745,7 @@ IIIIIIJJJJJJ
         let record = Record::with_attrs("id", None, b"ACGT@A", b"!!!!!!");
 
         let actual = record.check().unwrap_err();
-        let expected = "Non-IUPAC character found in sequence.";
+        let expected = "Invalid character found in sequence.";
 
         assert_eq!(actual, expected)
     }


### PR DESCRIPTION
Closes #472.

`Record::check()` on FASTA and FASTQ records used `is_ascii()` to validate the sequence, which lets through characters like `@`, `#`, digits, or whitespace — none of which are valid sequence characters under IUPAC.

This PR tightens the check: every byte in the sequence must be either an ASCII letter or one of `-`, `.`, `*` (the placeholder characters that show up in real FASTA files). The existing ASCII check still runs first, so non-ASCII inputs keep getting the `"Non-ascii character found in sequence."` error they got before.

FASTQ quality strings are not affected — they're still ASCII-checked only, since they're not sequence characters.

## Test plan

- [x] Added a regression test in each of `src/io/fasta.rs` and `src/io/fastq.rs` that constructs a record with `b"ACGT@A"` and asserts the new error.
- [x] All existing `io::fasta` and `io::fastq` tests still pass.
- [x] All doctests pass.