### PR TITLE
fix(fmindex): avoid usize underflow on backward_search for lex-smallest symbol

### DIFF
--- a/src/data_structures/fmindex.rs
+++ b/src/data_structures/fmindex.rs
@@ -161,8 +161,15 @@ pub trait FMIndexable {
             let less = self.less(a);
             pl = l;
             pr = r;
+            let occ_r = self.occ(r, a);
+            // Empty interval; the assignment to `r` below would underflow when
+            // `less == 0`. See https://github.com/rust-bio/rust-bio/issues/606.
+            if occ_r == 0 {
+                complete_match = false;
+                break;
+            }
             l = less + if l > 0 { self.occ(l - 1, a) } else { 0 };
-            r = less + self.occ(r, a) - 1;
+            r = less + occ_r - 1;
 
             // The symbol was not found if we end up with an empty interval.
             // Terminate the LF-mapping process. In this case, also mark that
@@ -571,7 +578,7 @@ impl<DBWT: Borrow<BWT>, DLess: Borrow<Less>, DOcc: Borrow<Occ>> FMDIndex<DBWT, D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alphabets::dna;
+    use crate::alphabets::{dna, Alphabet};
     use crate::data_structures::bwt::{bwt, less, Occ};
     use crate::data_structures::suffix_array::suffix_array;
 
@@ -666,6 +673,32 @@ mod tests {
 
         assert_eq!(partial_match_len, 4);
         assert_eq!(positions, [3]);
+    }
+
+    // Regression test for https://github.com/rust-bio/rust-bio/issues/606:
+    // searching for a pattern containing the lex-smallest symbol of the
+    // alphabet used to underflow `r` and crash with an out-of-bounds read.
+    #[test]
+    fn test_fmindex_backward_search_smallest_symbol_no_panic() {
+        // `\0` is both the sentinel (terminal, lex-smallest) and a regular
+        // alphabet symbol with `less[\0] == 0`.
+        let text = b"AAA\0";
+        let alphabet = Alphabet::new(b"\0A");
+        let sa = suffix_array(text);
+        let bwt = bwt(text, &sa);
+        let less = less(&bwt, &alphabet);
+        let occ = Occ::new(&bwt, 3, &alphabet);
+        let fm = FMIndex::new(&bwt, &less, &occ);
+
+        // Pattern is not in the text. Processing the trailing `\0`s in
+        // reverse order used to underflow `r` and panic on the next step.
+        let pattern = b"A\0\0";
+        let result = fm.backward_search(pattern.iter());
+
+        match result {
+            BackwardSearchResult::Absent | BackwardSearchResult::Partial(_, _) => {}
+            BackwardSearchResult::Complete(_) => panic!("pattern is not in text"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #606.

`FMIndexable::backward_search` panics with an out-of-bounds index when the searched pattern includes the lex-smallest symbol of the alphabet (where `less[a] == 0`) at a position where it has not yet occurred in the BWT prefix.

The arithmetic `r = less + self.occ(r, a) - 1` underflows `usize` to `usize::MAX` when both `less` and `occ(r, a)` are zero. The existing `l > r` empty-interval check that follows the assignment cannot detect this case because `0 > usize::MAX` is false. The next loop iteration then calls `occ(r, a)` with the underflowed `r` and panics.

This was reported by @RagnarGrootKoerkamp who built an FM-index over a full `0..=255` alphabet, which makes byte `0` the lex-smallest symbol.

## Fix

Detect the empty-interval case (`occ(r, a) == 0`) before the subtraction and break the LF-mapping loop early. This is the same termination condition the existing `l > r` check enforces — just hoisted past the underflowing arithmetic, so it actually fires.

Mathematically equivalent for all non-buggy inputs:
- If `occ(r, a) == 0`, the symbol does not appear in `BWT[0..=r]`, so it cannot appear in `BWT[l..=r]` either — the new SA interval is necessarily empty.
- If `occ(r, a) > 0` but `occ(l-1, a) == occ(r, a)`, the existing `l > r` check still catches it (no underflow because `less + occ_r - 1 >= less >= 0`).

## Test plan

- [x] Added a regression test that builds an FM-index over `b"AAA\0"` and searches for `b"A\0\0"`. On master this panics with `index out of bounds`. With the fix it terminates cleanly with `BackwardSearchResult::Partial` or `Absent`.
- [x] All existing `data_structures::fmindex` tests still pass.