### PR TITLE
fix(test): import RngExt for random_range in rank_select test

### DIFF
--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -415,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_select_against_naive_randomized() {
-        use rand::{Rng, SeedableRng};
+        use rand::{RngExt, SeedableRng};
         let mut rng = rand::rngs::StdRng::seed_from_u64(0xdead_beef);
         for _ in 0..50 {
             let n: u64 = 64 + rng.random_range(0..4096);


### PR DESCRIPTION
## Summary

The `test_select_against_naive_randomized` test in `src/data_structures/rank_select.rs` calls `rng.random_range(...)`, but only imports `Rng` and `SeedableRng`. In rand 0.10 the `random_range` method lives on a new `RngExt` trait, so master currently fails to build tests on stable (and on every other testing matrix entry). This one-line fix swaps the `Rng` import for `RngExt`.

## Why master ended up red

Two recently merged PRs are individually fine but conflict in combination:

- #659 bumped rand from 0.9 to 0.10 (merged 09:24 UTC, 2026-05-02).
- #664 added the `random_range` call in this test (merged 10:38 UTC, 2026-05-02).

#664's CI ran at 09:25, just after #659 merged but before #664 was rebased onto the new master, so it tested against rand 0.9 where `Rng::random_range` exists. The merge button was clicked an hour later without re-running CI on the rebased combination.

Suggestion (entirely your call): if you'd like to avoid this class of merge race in the future, GitHub has a "Require branches to be up to date before merging" toggle under Settings > Branches (or as part of a ruleset). Happy to file a separate issue if that's a better place to discuss.

## Test plan

- [x] `cargo test --lib data_structures::rank_select::tests::test_select_against_naive_randomized` passes locally
- [x] `cargo test --lib` passes (469 tests)
- [ ] CI green on this PR
