### PR TITLE
fix: import RngExt so tests and benches compile with rand 0.10

### DIFF
--- a/benches/fasta_buffer_size.rs
+++ b/benches/fasta_buffer_size.rs
@@ -15,7 +15,7 @@ const NUCS: [u8; 4] = [b'A', b'C', b'T', b'G'];
 
 fn random_seq<RNG>(length: usize, rng: &mut RNG) -> Vec<u8>
 where
-    RNG: rand::Rng,
+    RNG: rand::RngExt,
 {
     (0..length).map(|_| NUCS[rng.random_range(0..=3)]).collect()
 }

--- a/benches/fastx.rs
+++ b/benches/fastx.rs
@@ -5,7 +5,7 @@ extern crate test;
 use bio::io::{fasta, fastx};
 use rand::distr::Alphanumeric;
 use rand::rngs::StdRng;
-use rand::Rng;
+use rand::RngExt;
 use rand::SeedableRng;
 use std::io;
 use test::Bencher;

--- a/src/data_structures/rank_select.rs
+++ b/src/data_structures/rank_select.rs
@@ -415,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_select_against_naive_randomized() {
-        use rand::{Rng, SeedableRng};
+        use rand::{RngExt, SeedableRng};
         let mut rng = rand::rngs::StdRng::seed_from_u64(0xdead_beef);
         for _ in 0..50 {
             let n: u64 = 64 + rng.random_range(0..4096);


### PR DESCRIPTION
## Problem

On a fresh checkout, `cargo test` fails to compile:

```
error[E0599]: no method named `random_range` found for struct `StdRng`
help: trait `RngExt` which provides `random_range` is implemented but not
      in scope; perhaps you want to import it
```

The `rand 0.9 → 0.10` bump (#659) moved `random_range` (and `sample`, `random`) from the `Rng` trait to the new `RngExt` extension trait, but the randomized `rank_select` test and the `fastx` / `fasta_buffer_size` benches still imported only `Rng`. Since no `Cargo.lock` is committed, `rand` resolves to 0.10 and the build breaks.

## Fix

Bring `RngExt` into scope where these methods are called, and drop the now-unused `Rng` import from `fastx`.

## Verification

- `cargo test --all` → 636 passed, 0 failed
- `cargo +nightly build --benches` → compiles cleanly