### PR TITLE
chore: add keywords and categories to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ documentation = "https://docs.rs/bio"
 readme = "README.md"
 license = "MIT"
 edition = "2018"
+keywords = ["bioinformatics", "alignment", "fasta", "suffix-array", "pattern-matching"]
+categories = ["science::bioinformatics", "algorithms", "data-structures", "parser-implementations"]
 include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 
 [package.metadata.release]


### PR DESCRIPTION
Closes #518.

## Problem

The published crate has no `keywords` or `categories` in its manifest, which hurts discoverability on crates.io (the crate doesn't appear under any category listing or keyword search).

## Change

Add five keywords and four standard category slugs that reflect what the crate actually provides:

```toml
keywords = ["bioinformatics", "alignment", "fasta", "suffix-array", "pattern-matching"]
categories = ["science::bioinformatics", "algorithms", "data-structures", "parser-implementations"]
```

All four category slugs are valid entries from the official crates.io category list, and the five keywords respect the registry limits (≤ 5 keywords, each ≤ 20 chars). `cargo verify-project` passes.