### PR TITLE
fix(pattern_matching): reject 64-symbol patterns in shift_and and bndm

### DIFF
--- a/src/pattern_matching/bndm.rs
+++ b/src/pattern_matching/bndm.rs
@@ -4,7 +4,7 @@
 // except according to those terms.
 
 //! Backward nondeterministic DAWG matching (BNDM).
-//! Best-case complexity: O(n / m) with pattern of length m <= 64 and text of length n.
+//! Best-case complexity: O(n / m) with pattern of length m < 64 and text of length n.
 //! Worst case complexity: O(n * m).
 //!
 //! # Example
@@ -40,7 +40,7 @@ impl BNDM {
     {
         let pattern = pattern.into_iter();
         let m = pattern.len();
-        assert!(m <= 64, "Expecting a pattern of at most 64 symbols.");
+        assert!(m < 64, "Expecting a pattern of less than 64 symbols.");
         // take the reverse pattern and build nondeterministic
         // suffix automaton
         let (masks, accept) = masks(pattern.rev());
@@ -128,5 +128,26 @@ mod tests {
         let pattern = b"dhjalk";
         let bndm = BNDM::new(pattern);
         assert_eq!(bndm.find_all(text).collect_vec(), [0]);
+    }
+
+    #[test]
+    fn test_max_length_pattern() {
+        // 63 symbols is the longest supported pattern. Previously a 64-symbol
+        // pattern panicked with a shift overflow at `1u64 << m` (#203); 63 must
+        // work correctly.
+        let pattern = [b'A'; 63];
+        let mut text = vec![b'C'; 10];
+        text.extend_from_slice(&pattern);
+        let bndm = BNDM::new(&pattern[..]);
+        assert_eq!(bndm.find_all(&text[..]).collect_vec(), [10]);
+    }
+
+    #[test]
+    #[should_panic(expected = "less than 64 symbols")]
+    fn test_too_long_pattern_panics() {
+        // 64 symbols would overflow the u64 masks / the `1u64 << m` shift; it
+        // must be rejected at construction time (#203).
+        let pattern = [b'A'; 64];
+        BNDM::new(&pattern[..]);
     }
 }

--- a/src/pattern_matching/shift_and.rs
+++ b/src/pattern_matching/shift_and.rs
@@ -4,7 +4,7 @@
 // except according to those terms.
 
 //! `ShiftAnd` algorithm for pattern matching.
-//! Patterns may contain at most 64 symbols.
+//! Patterns may contain less than 64 symbols.
 //! Complexity: O(n) with text length n.
 //!
 //! # Example
@@ -39,7 +39,7 @@ impl ShiftAnd {
     {
         let pattern = pattern.into_iter();
         let m = pattern.len();
-        assert!(m <= 64, "Expecting a pattern of at most 64 symbols.");
+        assert!(m < 64, "Expecting a pattern of less than 64 symbols.");
         let (masks, accept) = masks(pattern);
 
         ShiftAnd { m, masks, accept }
@@ -136,5 +136,25 @@ mod tests {
         let pattern = b"CC";
         let shiftand = ShiftAnd::new(pattern);
         assert_eq!(shiftand.find_all(text).collect_vec(), [0, 3, 6]);
+    }
+
+    #[test]
+    fn test_max_length_pattern() {
+        // 63 symbols is the longest supported pattern (the masks are u64, so
+        // bit 63 is the highest usable position). It must still match.
+        let pattern = [b'A'; 63];
+        let mut text = vec![b'C'; 10];
+        text.extend_from_slice(&pattern);
+        let shiftand = ShiftAnd::new(&pattern);
+        assert_eq!(shiftand.find_all(&text).collect_vec(), [10]);
+    }
+
+    #[test]
+    #[should_panic(expected = "less than 64 symbols")]
+    fn test_too_long_pattern_panics() {
+        // 64 symbols would overflow the u64 masks; this must be rejected up
+        // front rather than silently producing a wrong `accept` mask (#203).
+        let pattern = [b'A'; 64];
+        ShiftAnd::new(&pattern);
     }
 }


### PR DESCRIPTION
Closes #203.

## Problem

`ShiftAnd` and `BNDM` store their masks in a `u64`, so the highest usable bit position is 63 and the longest pattern they can represent is **63** symbols. However:

- both constructors assert `m <= 64`,
- the `shift_and` and `bndm` module docs say "at most 64 symbols" / "m <= 64".

A 64-symbol pattern doesn't actually work:

- `shift_and::masks` runs `bit *= 2` once per symbol, reaching `2^64` after 64 iterations — it overflows (panics in debug, wraps to `0` in release), and returns a silently wrong `accept = 0` so nothing ever matches.
- `BNDM` panics on `1u64 << 64` (shift overflow) as reported in #203.

The parent `pattern_matching` module doc already says the correct thing ("less than 64 symbols"), so the two submodules were simply inconsistent with reality and with their own parent.

## Change

This keeps the existing `u64` implementation (no performance change) and just makes the boundary honest:

- tighten both asserts to `m < 64` with a matching message,
- fix the two module-level doc comments,
- add boundary tests in each module: a 63-symbol pattern still matches correctly, and a 64-symbol pattern is rejected at construction time instead of silently producing wrong results or panicking deep inside the iterator.

For patterns of 64+ symbols, the block-based Myers implementation (`pattern_matching::myers`) remains the right tool.

## Verification

- `cargo test --lib` → 486 passed, 0 failed
- `cargo fmt --check` and `cargo clippy --lib` → clean